### PR TITLE
dependency bot alert for `Gemfile.lock`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     ffi (1.11.1-x86-mingw32)
     forwardable-extended (2.6.0)
     jekyll (3.6.3)
-      addressable (~> 2.4)
+      addressable (>= 2.8.0)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)


### PR DESCRIPTION
1 addressable vulnerability found in Gemfile.lock

- Upgrade `addressable` from version `2.4` to version 2.8.0 or later